### PR TITLE
Completed removing the map on the crossreference map on the component…

### DIFF
--- a/client/src/components/map/crossReference.js
+++ b/client/src/components/map/crossReference.js
@@ -304,6 +304,7 @@ class CrossReference extends Component {
 
     componentDidUpdate(prevProps, prevState, snapshot) {
         if(prevProps.location.pathname !== this.props.location.pathname) {
+            this.map.remove();
             this.getData();
         }
     }


### PR DESCRIPTION
…didUpdate so that we are no longer getting the warning of Too many active WebGL contexts